### PR TITLE
Enable assigning existing maintenance plans

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,8 +94,16 @@
                     <option value="Mensual">Mensual</option>
                     <option value="Trimestral">Trimestral</option>
                     <option value="Semestral">Semestral</option>
-                    <option value="Anual">Anual</option>
+                <option value="Anual">Anual</option>
                 </select>
+            </div>
+
+            <div class="form-group">
+                <label for="plan-existente">Asignar Plan Existente:</label>
+                <select id="plan-existente">
+                    <option value="">-- Seleccionar Plan --</option>
+                </select>
+                <button type="button" class="action-button" onclick="asignarPlanAEquipamiento()">Asignar al Equipamiento</button>
             </div>
 
             <!-- Añadir después del selector de periodicidad -->


### PR DESCRIPTION
## Summary
- allow assigning an existing maintenance plan to another equipment
- add dropdown in Plans tab to pick existing plan
- track plans by key and equipment when editing or deleting
- refresh plan dropdown on load and after updates

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6842bbfe1ac883288b68ef897d668257